### PR TITLE
PB-673: Fiks basepath for å hente inn assets med express

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "lint": "eslint --ext .js,.jsx src",
     "bump": "npx npm-check-updates --target minor -u && npm i"
   },
+  "homepage": "/person/mine-saker",
   "eslintConfig": {
     "plugins": [
       "jsx-a11y"


### PR DESCRIPTION
Har brukt homepage for å sette basepath når appen kjøres med express. Dette gjør at javascript og css blir hentet inn fra riktig path.

PB-673: Fiks basepath for å hente inn assets med express