### PR TITLE
Setter korrekt context path for backend-en

### DIFF
--- a/src/urls.js
+++ b/src/urls.js
@@ -7,12 +7,12 @@ const getEnvironment = () => {
 
 const SAKSTEMAER_URL = {
   development: "https://www.api.nav.no/person/mine-saker-api/sakstemaer",
-  production: "https://mine-saker-api.dev.nav.no/mine-saker-api/sakstemaer",
+  production: "https://mine-saker-api.dev.nav.no/person/mine-saker-api/sakstemaer",
 };
 
 const JOURNALPOSTER_URL = {
   development: "https://www.api.nav.no/person/mine-saker-api/journalposter",
-  production: "https://mine-saker-api.dev.nav.no/mine-saker-api/journalposter",
+  production: "https://mine-saker-api.dev.nav.no/person/mine-saker-api/journalposter",
 };
 
 export const sakstemaerUrl = SAKSTEMAER_URL[getEnvironment()];


### PR DESCRIPTION
Det står `production` for variablen under, men det er den som brukes ved kjøring i dev.