### PR TITLE
Bytter til å bruke nytt endepunkt for å hente journalposter

### DIFF
--- a/src/pages/sakstema/Sakstema.js
+++ b/src/pages/sakstema/Sakstema.js
@@ -11,7 +11,7 @@ import "./Sakstema.less";
 
 const Sakstema = () => {
   const { temakode } = useParams();
-  const { data, isLoading, isError } = useQuery(`${journalposterUrl}?sakstemakode=${temakode}`, fetchData);
+  const { data, isLoading, isError } = useQuery(`${journalposterUrl}/${temakode}`, fetchData);
 
   if (isLoading) {
     return <Spinner message="Laster inn siden..." />;


### PR DESCRIPTION
Bytter til å bruke det nye endepunktet `<mine-saker-api>/journalposter/<sakstemakode>`.

Både det gamle endepunktet og det nye er tilgjengelig ute i miljøene.