### PR TITLE
PB-700: Klargjør for unntak av lenker i om saken panelet

### DIFF
--- a/src/components/liste/lenkeliste/Lenkeliste.js
+++ b/src/components/liste/lenkeliste/Lenkeliste.js
@@ -1,23 +1,23 @@
 import React from "react";
+import { useParams } from "react-router-dom";
 import Lenke from "nav-frontend-lenker";
 import { HoyreChevron } from "nav-frontend-chevron";
-import generelleLenker, { dagpengeLenker } from "./Lenker";
+import useTemaException from "../../../hooks/useTemaException";
+import lenker from "./Lenker";
 import "./Lenkeliste.less";
 
-const Lenkeliste = ({ data }) => {
+const Lenkeliste = () => {
+  const { temakode } = useParams();
+  const isTemaException = useTemaException(temakode);
+  const lenkeKey = isTemaException ? temakode : "GENERELLE";
+
   return (
     <div className="lenkeliste">
-      {data && data[0].kode === "DAG"
-        ? dagpengeLenker.map((lenke) => (
-            <Lenke className="lenkeliste-item blokk-xxxs" href={lenke.url}>
-              <HoyreChevron className="lenkeliste-item__chevron" /> {lenke.tekst}
-            </Lenke>
-          ))
-        : generelleLenker.map((lenke) => (
-            <Lenke className="lenkeliste-item blokk-xxxs" href={lenke.url}>
-              <HoyreChevron className="lenkeliste-item__chevron" /> {lenke.tekst}
-            </Lenke>
-          ))}
+      {lenker[lenkeKey].map((lenke) => (
+        <Lenke className="lenkeliste-item blokk-xxxs" href={lenke.url}>
+          <HoyreChevron className="lenkeliste-item__chevron" /> {lenke.tekst}
+        </Lenke>
+      ))}
     </div>
   );
 };

--- a/src/components/liste/lenkeliste/Lenker.js
+++ b/src/components/liste/lenkeliste/Lenker.js
@@ -30,7 +30,7 @@ const generelleLenker = [
   },
 ];
 
-export const dagpengeLenker = [
+const dagpengeLenker = [
   ...generelleLenker,
   {
     url: dagpengerUrl,
@@ -38,4 +38,9 @@ export const dagpengeLenker = [
   },
 ];
 
-export default generelleLenker;
+const lenker = {
+  GENERELLE: generelleLenker,
+  DAG: dagpengeLenker,
+};
+
+export default lenker;

--- a/src/hooks/useTemaException.js
+++ b/src/hooks/useTemaException.js
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+const exceptions = ["DAG"];
+
+const useTemaException = (temakode) => {
+  const [isException, setIsException] = useState(false);
+
+  useEffect(() => {
+    setIsException(exceptions.includes(temakode));
+  }, [temakode]);
+
+  return isException;
+};
+
+export default useTemaException;


### PR DESCRIPTION
Klargjort for flere unntak av lenker i om saken panelet. Nå skal det være lett å legge inn egne lenker for sakstemasider, f.eks lenker til faktaark på nav.no eller til andre innsyn i sak-sider.

* Bruker useParams for å hente temakode
* Laget en custom hook som sjekker om en sakstemaside skal ha egne lenker

