### PR TITLE
PB-827: Flere type checks

### DIFF
--- a/src/components/liste/dokumentliste/DokumentListe.js
+++ b/src/components/liste/dokumentliste/DokumentListe.js
@@ -1,5 +1,5 @@
 import React from "react";
-import PropTypes from "prop-types";
+import { string } from "prop-types";
 import { Normaltekst } from "nav-frontend-typografi";
 import Liste from "../Liste";
 import ListeElement from "../../listelement/ListeElement";
@@ -49,7 +49,7 @@ const DokumentListe = ({ sakstemaKey }) => {
 };
 
 DokumentListe.propTypes = {
-  sakstemaKey: PropTypes.string.isRequired,
+  sakstemaKey: string.isRequired,
 };
 
 export default DokumentListe;

--- a/src/components/liste/vedleggsliste/Vedleggsliste.js
+++ b/src/components/liste/vedleggsliste/Vedleggsliste.js
@@ -1,8 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Normaltekst } from "nav-frontend-typografi";
 import VedleggslisteItem from "./VedleggslisteItem";
 import "./Vedleggsliste.less";
+import JournalpostType from "../../../types/JournalpostType";
 
 const Vedleggsliste = ({ journalpost }) => {
   const byVedlegg = (dokument) => dokument.dokumenttype === "VEDLEGG";
@@ -27,8 +27,8 @@ const Vedleggsliste = ({ journalpost }) => {
   );
 };
 
-Vedleggsliste.prototype = {
-  journalpost: PropTypes.object.isRequired,
+Vedleggsliste.propTypes = {
+  journalpost: JournalpostType,
 };
 
 export default Vedleggsliste;

--- a/src/components/listelement/dokumentelement/Dokumentelement.js
+++ b/src/components/listelement/dokumentelement/Dokumentelement.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import ChevronlenkeBase from "../../chevronlenke/ChevronlenkeBase";
 import Dokumentlenke from "../../chevronlenke/dokumentlenke/Dokumentlenke";
 import MaskertIkon from "../../../assets/MaskertIkon";
@@ -7,6 +6,8 @@ import { Ingress, Undertekst } from "nav-frontend-typografi";
 import { EtikettAdvarsel } from "nav-frontend-etiketter";
 import { formatToReadableDate, setLocaleDate } from "../../../utils/date";
 import "./Dokumentelement.less";
+import JournalpostType from "../../../types/JournalpostType";
+import DokumentType from "../../../types/DokumentType";
 
 const Dokumentelement = ({ journalpost, dokument }) => {
   if (dokument.brukerHarTilgang === false) {
@@ -41,9 +42,9 @@ const Dokumentelement = ({ journalpost, dokument }) => {
   );
 };
 
-Dokumentelement.prototype = {
-  journalpost: PropTypes.object.isRequired,
-  document: PropTypes.object.isRequired,
+Dokumentelement.propTypes = {
+  journalpost: JournalpostType,
+  dokument: DokumentType,
 };
 
 export default Dokumentelement;

--- a/src/components/listelement/vedleggselement/Vedleggselement.js
+++ b/src/components/listelement/vedleggselement/Vedleggselement.js
@@ -1,10 +1,9 @@
 import React from "react";
-import PropTypes from "prop-types";
-
 import ChevronlenkeBase from "../../chevronlenke/ChevronlenkeBase";
 import Dokumentlenke from "../../chevronlenke/dokumentlenke/Dokumentlenke";
 import Vedleggsliste from "../../liste/vedleggsliste/Vedleggsliste";
 import "./Vedleggselement.less";
+import JournalpostType from "../../../types/JournalpostType";
 
 const Vedleggselement = ({ journalpost }) => {
   const byHoveddokument = (dokument) => dokument.dokumenttype === "HOVED";
@@ -27,7 +26,7 @@ const Vedleggselement = ({ journalpost }) => {
 };
 
 Vedleggselement.propTypes = {
-  journalpost: PropTypes.object,
+  journalpost: JournalpostType,
 };
 
 export default Vedleggselement;

--- a/src/types/DokumentType.js
+++ b/src/types/DokumentType.js
@@ -1,0 +1,10 @@
+import { shape, string, bool } from "prop-types";
+
+const DokumentType = shape({
+  tittel: string.isRequired,
+  dokumentInfoId: string.isRequired,
+  brukerHarTilgang: bool.isRequired,
+  dokumenttype: string,
+});
+
+export default DokumentType;

--- a/src/types/JournalpostType.js
+++ b/src/types/JournalpostType.js
@@ -1,0 +1,19 @@
+import { shape, arrayOf, string, bool } from "prop-types";
+import DokumentType from "./DokumentType";
+
+const avsenderMottaker = shape({
+  innloggetBrukerErAvsender: bool.isRequired,
+  type: string.isRequired,
+});
+
+const JournalpostType = shape({
+  tittel: string.isRequired,
+  journalpostId: string.isRequired,
+  journalposttype: string.isRequired,
+  harVedlegg: bool,
+  avsenderMottaker: avsenderMottaker,
+  sisteEndret: string.isRequired,
+  dokumenter: arrayOf(DokumentType),
+});
+
+export default JournalpostType;


### PR DESCRIPTION
Typechecket flere komponenter med prop-types. 
Lagde types folder for props(journalpost og dokument) brukes i flere komponenter.