### PR TITLE
La inn visning av lenken til sosialhjelp fra sakstemasiden KOM

### DIFF
--- a/src/components/liste/lenkeliste/Lenker.js
+++ b/src/components/liste/lenkeliste/Lenker.js
@@ -1,4 +1,4 @@
-import { dagpengerUrl, foreldrepengerUrl, hjelpemidlerUrl, klagerettigheterUrl, lesmeromdagpengerUrl, stonadervedtiltakUrl, sykemeldingerUrl } from "../../../urls";
+import { dagpengerUrl, foreldrepengerUrl, hjelpemidlerUrl, klagerettigheterUrl, lesmeromdagpengerUrl, sosialhjelpUrl, stonadervedtiltakUrl, sykemeldingerUrl } from "../../../urls";
 import { kontaktOssUrl, lastOppVedleggUrl, opplysningspliktUrl, saksbehandlingstiderUrl } from "../../../urls";
 import { sosialhjelpAktivitetUrl, sosialhjelpVeiviserUrl, tilbakemeldingerUrl } from "../../../urls";
 import { arbeidsavklaringspengerUrl } from "../../../urls";
@@ -71,6 +71,10 @@ const sykefravaerLenker = [
 ];
 
 const sosialhjelpLenker = [
+  {
+    url: sosialhjelpUrl,
+    tekst: "Din økonomiske sosialhjelp",
+  },
   {
     url: kontaktOssUrl,
     tekst: "Kontakt oss",


### PR DESCRIPTION
PB-820: https://jira.adeo.no/secure/RapidBoard.jspa?rapidView=20606&projectKey=PB&view=detail&selectedIssue=PB-820

Lagt til visning av lenke til https://www-q1.dev.nav.no/sosialhjelp/innsyn fra sakstemasiden KOM. Lenketeksten er "Din økonomiske sosialhjelp". Sjekket at lenken fungerer i dev.