### PR TITLE
Maskering av vedleggselement

### DIFF
--- a/src/components/liste/vedleggsliste/Vedleggsliste.js
+++ b/src/components/liste/vedleggsliste/Vedleggsliste.js
@@ -18,6 +18,7 @@ const Vedleggsliste = ({ journalpost }) => {
               dokumentId={dokument.dokumentInfoId}
               journalpostId={journalpost.journalpostId}
               brukerHarTilgang={dokument.brukerHarTilgang}
+              tittel={dokument.tittel}
             >
               {dokument.tittel}
             </VedleggslisteItem>

--- a/src/components/liste/vedleggsliste/Vedleggsliste.less
+++ b/src/components/liste/vedleggsliste/Vedleggsliste.less
@@ -5,7 +5,13 @@
 }
 
 .vedleggsliste-item {
+  display: flex;
+  flex-direction: row;
   padding-top: 0.25em;
+
+  .vedleggsliste-item-undertekst {
+    margin-right: 1em;
+  }
 }
 
 .vedleggslenke {

--- a/src/components/liste/vedleggsliste/VedleggslisteItem.js
+++ b/src/components/liste/vedleggsliste/VedleggslisteItem.js
@@ -2,16 +2,21 @@ import React from "react";
 import PropTypes from "prop-types";
 import Lenke from "nav-frontend-lenker";
 import { HoyreChevron } from "nav-frontend-chevron";
+import { Undertekst } from "nav-frontend-typografi";
+import { EtikettAdvarsel } from "nav-frontend-etiketter";
 import { dokumentUrl } from "../../../urls";
 
-const VedleggslisteItem = ({ journalpostId, dokumentId, brukerHarTilgang, children }) => {
-  //Legg inn kosmetiske endringer for hva som skal vises til brukere uten tilgang.
+const VedleggslisteItem = ({ journalpostId, dokumentId, brukerHarTilgang, tittel, children }) => {
+  
   if(brukerHarTilgang === false) {
     return(
       <li className="vedleggsliste-item">
-      <Lenke className="vedleggslenke" href={`${dokumentUrl}/${journalpostId}/${dokumentId}`}>
-        <HoyreChevron className="vedleggslenke__chevron" /> {children}
-      </Lenke>
+      <Undertekst className="vedleggsliste-item-undertekst">
+        {tittel}
+      </Undertekst>
+      <EtikettAdvarsel className="maskert-etiketter__advarsel" mini>
+        Vedlegget kan ikke vises
+      </EtikettAdvarsel>
     </li>
     );
   }

--- a/src/mocks/journalposter.json
+++ b/src/mocks/journalposter.json
@@ -27,7 +27,7 @@
           {
             "tittel": "Ettersending til Klage/Anke",
             "dokumentInfoId": "5151561249",
-            "brukerHarTilgang": true,
+            "brukerHarTilgang": false,
             "dokumenttype": "VEDLEGG"
           }
         ]


### PR DESCRIPTION
Har lagt til en sjekk for om brukerHarTilgang === false for vedleggselementer (Lik logikk som for dokumentelementer).
Hvis bruker ikke har tilgang vises det da kun en tekst med tittelen på vedlegget, samt en rød boks som gir informasjon om at vedlegget ikke er tilgjengelig.