### PR TITLE
Lagt inn maskering av vedlegg på riktig nivå

### DIFF
--- a/src/components/listelement/vedleggselement/Vedleggselement.js
+++ b/src/components/listelement/vedleggselement/Vedleggselement.js
@@ -1,4 +1,8 @@
 import React from "react";
+import MaskertIkon from "../../../assets/MaskertIkon";
+import { Ingress, Undertekst } from "nav-frontend-typografi";
+import { EtikettAdvarsel } from "nav-frontend-etiketter";
+import { formatToReadableDate, setLocaleDate } from "../../../utils/date";
 import ChevronlenkeBase from "../../chevronlenke/ChevronlenkeBase";
 import Dokumentlenke from "../../chevronlenke/dokumentlenke/Dokumentlenke";
 import Vedleggsliste from "../../liste/vedleggsliste/Vedleggsliste";
@@ -7,22 +11,45 @@ import JournalpostType from "../../../types/JournalpostType";
 
 const Vedleggselement = ({ journalpost }) => {
   const byHoveddokument = (dokument) => dokument.dokumenttype === "HOVED";
-  const hoveddokument = journalpost.dokumenter.find(byHoveddokument);
+  const hovedDokument = journalpost.dokumenter.find(byHoveddokument);
 
-  return (
-    <React.Fragment>
-      <ChevronlenkeBase dato={journalpost.sisteEndret} hideBorder>
-        <Dokumentlenke
-          journalpostId={journalpost.journalpostId}
-          tekst={journalpost.tittel}
-          dokumentId={hoveddokument.dokumentInfoId}
-        />
-      </ChevronlenkeBase>
-      <div className="vedleggselement">
-        <Vedleggsliste journalpost={journalpost} />
+  if (hovedDokument.brukerHarTilgang === true) {
+    return (
+      <React.Fragment>
+        <ChevronlenkeBase dato={journalpost.sisteEndret} hideBorder>
+          <Dokumentlenke
+            journalpostId={journalpost.journalpostId}
+            tekst={journalpost.tittel}
+            dokumentId={hovedDokument.dokumentInfoId}
+          />
+        </ChevronlenkeBase>
+        <div className="vedleggselement">
+          <Vedleggsliste journalpost={journalpost} />
+        </div>
+      </React.Fragment>
+    );
+  } 
+  else 
+  {
+    setLocaleDate();
+    
+    return (
+      <div className="maskertelement">
+        <div className="maskert-header">
+          <MaskertIkon />
+          <Ingress className="maskert-header__tekst">{hovedDokument.tittel}</Ingress>
+        </div>
+        <div className="maskert-etiketter">
+          <Undertekst className="maskert-etiketter__dato">
+            {`Sist endret ${formatToReadableDate(journalpost.sisteEndret)}`}
+          </Undertekst>
+          <EtikettAdvarsel className="maskert-etiketter__advarsel" mini>
+            Dokumentet kan ikke vises
+          </EtikettAdvarsel>
+        </div>
       </div>
-    </React.Fragment>
-  );
+    )
+  }
 };
 
 Vedleggselement.propTypes = {


### PR DESCRIPTION
Lagt inn maskering av vedlegg for bruker på samme nivå som for dokumentelementer. Dette gjøres fordi den forrige fiksen av maskering av vedlegg ble lagt inn et nivå dypere, altså i vedleggslisteelement. Lar denne ligge der, i tilfelle det eksisterer tilfeller hvor hoveddokumentet kan vises til bruker, men et spesifikt vedlegg skal maskeres.